### PR TITLE
merge Assist bootstrap

### DIFF
--- a/src/definitions.ads
+++ b/src/definitions.ads
@@ -6,7 +6,7 @@ package Definitions is
    pragma Pure;
 
    raven_version_major : constant String := "3";
-   raven_version_minor : constant String := "45";
+   raven_version_minor : constant String := "46";
    copyright_years     : constant String := "2015-2025";
 
    raven_tool        : constant String := "ravenadm";

--- a/src/hierarchy.adb
+++ b/src/hierarchy.adb
@@ -42,13 +42,11 @@ package body Hierarchy is
                return;
             end if;
             features := Archive.Unix.get_charactistics (rootdir & relpath);
-            case features.ftype is
-               when Archive.unsupported =>
-                  RAX.writeln (log_fd, debugmsg & " or DNE.  Retrying.");
-                  delay (0.05);
-                  features := Archive.Unix.get_charactistics (rootdir & relpath);
-               when others => null;
-            end case;
+            if features.error then
+               RAX.writeln (log_fd, debugmsg & ".  Retrying.");
+               delay (0.05);
+               features := Archive.Unix.get_charactistics (rootdir & relpath);
+            end if;
             myrec.gid    := features.gid;
             myrec.uid    := features.uid;
             myrec.perms  := features.perms;
@@ -130,13 +128,11 @@ package body Hierarchy is
                return;
             end if;
             features := Archive.Unix.get_charactistics (rootdir & relpath);
-            case features.ftype is
-               when Archive.unsupported =>
-                  RAX.writeln (log_fd, debugmsg &  " or DNE.  Retrying.");
-                  delay (0.05);
-                  features := Archive.Unix.get_charactistics (rootdir & relpath);
-               when others => null;
-            end case;
+            if features.error then
+               RAX.writeln (log_fd, debugmsg &  ".  Retrying.");
+               delay (0.05);
+               features := Archive.Unix.get_charactistics (rootdir & relpath);
+            end if;
             if DC.Contains (entkey) then
                myrec := DC.Element (entkey);
                case myrec.ftype is

--- a/src/hierarchy.adb
+++ b/src/hierarchy.adb
@@ -119,6 +119,13 @@ package body Hierarchy is
                return;
             end if;
             features := Archive.Unix.get_charactistics (rootdir & relpath);
+            case features.ftype is
+               when Archive.unsupported =>
+                  RAX.writeln (log_fd, "debug: " & entname & ": stat() failed or DNE.  Retrying.");
+                  delay (0.05);
+                  features := Archive.Unix.get_charactistics (rootdir & relpath);
+               when others => null;
+            end case;
             if DC.Contains (entkey) then
                myrec := DC.Element (entkey);
                case features.ftype is
@@ -126,6 +133,7 @@ package body Hierarchy is
                      digest := (others => '0');
                   when Archive.unsupported =>
                      digest := (others => '0');
+                     RAX.writeln (log_fd, "debug: " & entname & ": stat() failed again.");
                   when Archive.regular | Archive.hardlink =>
                      digest := Blake_3.file_digest (rootdir & relpath);
                end case;

--- a/src/hierarchy.adb
+++ b/src/hierarchy.adb
@@ -139,7 +139,7 @@ package body Hierarchy is
             end case;
             if DC.Contains (entkey) then
                myrec := DC.Element (entkey);
-               case features.ftype is
+               case myrec.ftype is
                   when Archive.directory | Archive.symlink | Archive.fifo =>
                      digest := (others => '0');
                   when Archive.unsupported =>
@@ -158,10 +158,17 @@ package body Hierarchy is
                if not (M and then U and then G and then D and then T) then
                   modified.Append (entkey);
                   if not (M and then U and then G) then
-                     RAX.writeln (log_fd, "debug: " & entname & " MUG (" & myrec.perms'Img & " |" &
-                                    myrec.uid'Img & " |" & myrec.gid'Img & " )   current (" &
-                                    features.perms'Img & " |" & features.uid'Img & " |" &
-                                    features.gid'Img & " )");
+                     RAX.writeln (log_fd, "debug: " & entname & " MUGT (" &
+                                    myrec.perms'Img & " |" &
+                                    myrec.uid'Img & " |" &
+                                    myrec.gid'Img & " | " &
+                                    myrec.ftype'Img &
+                                    ")   current (" &
+                                    features.perms'Img & " |" &
+                                    features.uid'Img & " |" &
+                                    features.gid'Img & " | " &
+                                    features.ftype'Img &
+                                    ")");
                   end if;
                end if;
                DC.Update_Element (DC.Find (entkey), set_second'Access);

--- a/src/hierarchy.ads
+++ b/src/hierarchy.ads
@@ -41,7 +41,8 @@ package Hierarchy is
    procedure take_snapshot
      (DC        : in out Dirent_Collection.Map;
       rootdir   : String;
-      builder   : Positive);
+      builder   : Positive;
+      log_fd    : RAX.File_Descriptor);
 
    --  Given the results of the snapshot, this function displays any missing, extra or
    --  modified files and returns False if any of those occur.  (True means check passed)

--- a/src/pilot.adb
+++ b/src/pilot.adb
@@ -1347,6 +1347,7 @@ package body Pilot is
       function dupe_archive (origin, destino : String) return Boolean;
 
       binutils : constant String := "binutils";
+      genesis  : constant String := HT.USS (PM.configuration.dir_sysroot) & "/usr/share/GENESIS";
 
       function get_package_name (subpackage : String; use_prev : Boolean) return String
       is
@@ -1432,6 +1433,12 @@ package body Pilot is
             return False;
       end package_copy;
    begin
+      if DIR.Exists (genesis) then
+         --  This is a first generation system root manually constructed for the
+         --  purpose of bootstrapping on a new platform.  In this case, there are no
+         --  existing binutils or gcc subpackages to copy over yet.  Do nothing.
+         return True;
+      end if;
       return
         package_copy (binutils) and then
         package_copy ("ada_run") and then

--- a/src/port_specification-transform.adb
+++ b/src/port_specification-transform.adb
@@ -351,12 +351,13 @@ package body Port_Specification.Transform is
          apply_gcc_run_module (specs, variant, "c++", "cxx_run");
          apply_gcc_run_module (specs, variant, "fortran", "fortran_run");
          apply_gcc_run_module (specs, variant, "cclibs", "libs");
-         if platform_type = sunos or else platform_type = macos
+         if platform_type = macos
          then
             --  Solaris 10 doesn't use dl_iterate_phdr, so many packages have executables that
             --  requires libgcc_s.so.  Rather than specify potentially hundreds of C_USES
             --  keywords, just make ravensys-gcc:libs:std a run depends of every package (including
             --  gcc6, gcc7, gcc8 and later).
+            --  However, Solaris 11 / OmniOS does use dl_iterate_phdr so drop sunos condition
             add_exrun_cclibs (specs, variant);
          end if;
          apply_gcc_full_set (specs, variant);

--- a/src/port_specification-transform.adb
+++ b/src/port_specification-transform.adb
@@ -278,7 +278,10 @@ package body Port_Specification.Transform is
 
       end copy_option_over;
 
-      skip_compiler_packages : constant Boolean := Unix.env_variable_defined ("SKIPCCRUN");
+      skip_compiler_packages : constant Boolean :=
+        Unix.env_variable_defined ("SKIPCCRUN") or else
+        DIR.Exists (HT.USS (Parameters.configuration.dir_sysroot) & "/usr/share/GENESIS");
+
    begin
       specs.ops_helpers.Iterate (Process => copy_option_over'Access);
       apply_extraction_deps (specs);

--- a/src/port_specification.adb
+++ b/src/port_specification.adb
@@ -2304,7 +2304,7 @@ package body Port_Specification is
    --------------------------------------------------------------------------------------------
    --  adjust_defaults_port_parse
    --------------------------------------------------------------------------------------------
-   procedure adjust_defaults_port_parse (specs : in out Portspecs)
+   procedure adjust_defaults_port_parse (specs : in out Portspecs; skip_cc_run : Boolean)
    is
       procedure grow (Key : HT.Text; Element : in out group_list);
 
@@ -2341,7 +2341,7 @@ package body Port_Specification is
       then
          specs.df_index.Append (HT.SUS ("1"));
       end if;
-      if Unix.env_variable_defined ("SKIPCCRUN") then
+      if skip_cc_run then
          specs.fatal_rpath := False;
       end if;
       if specs.debugging_on then

--- a/src/port_specification.ads
+++ b/src/port_specification.ads
@@ -174,7 +174,7 @@ package Port_Specification is
    function deprecation_valid (specs : Portspecs) return Boolean;
 
    --  Perform any post-parsing adjustments necessary
-   procedure adjust_defaults_port_parse (specs : in out Portspecs);
+   procedure adjust_defaults_port_parse (specs : in out Portspecs; skip_cc_run : Boolean);
 
    --  Returns true if indicated option helper is empty
    function option_helper_unset

--- a/src/portscan-buildcycle.adb
+++ b/src/portscan-buildcycle.adb
@@ -69,7 +69,10 @@ package body PortScan.Buildcycle is
          return False;
       end if;
       if testing then
-         Hierarchy.take_snapshot (trackers (id).genesis, get_root (id), Positive (id));
+         Hierarchy.take_snapshot (DC      => trackers (id).genesis,
+                                  rootdir => get_root (id),
+                                  builder => Positive (id),
+                                  log_fd  => trackers (id).log_fd);
       end if;
       begin
          for phase in phases'Range loop
@@ -90,7 +93,10 @@ package body PortScan.Buildcycle is
 
             when configure =>
                if testing then
-                  Hierarchy.take_snapshot (trackers (id).preconfig, get_root (id), Positive (id));
+                  Hierarchy.take_snapshot (DC      => trackers (id).preconfig,
+                                           rootdir => get_root (id),
+                                           builder => Positive (id),
+                                           log_fd  => trackers (id).log_fd);
                end if;
                R := exec_phase_generic (id, phase, environ);
 

--- a/src/specification_parser.adb
+++ b/src/specification_parser.adb
@@ -731,7 +731,12 @@ package body Specification_Parser is
       if spec.get_parse_error = "" then
          spec.set_parse_error (late_validity_check_error (spec));
          if spec.get_parse_error = "" then
-            spec.adjust_defaults_port_parse;
+            declare
+               skip_cc_run : constant Boolean := Unix.env_variable_defined ("SKIPCCRUN") or else
+                 DIR.Exists (HT.USS (Parameters.configuration.dir_sysroot) & "/usr/share/GENESIS");
+            begin
+               spec.adjust_defaults_port_parse (skip_cc_run);
+            end;
             success := True;
          end if;
       end if;


### PR DESCRIPTION
This started as Solaris 11 bootstrap support which is probably finished
but not confirmed.  However, fixes to the tree integrity check (along with rvn-format update)
requires that we merge this now.